### PR TITLE
Fix 2 bugs and change settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'activerecord4-redshift-adapter', github: 'aamine/activerecord4-redshift-adapter'
+gem 'activerecord4-redshift-adapter', '~> 0.1.1'
 
 gemspec
 

--- a/lib/redshiftex/cli.rb
+++ b/lib/redshiftex/cli.rb
@@ -35,7 +35,7 @@ module Redshiftex
     option :path, type: :string, required: true, desc: 'path'
     option :excludes, type: :array, default: [],desc: 'excludes tables. can use regexp.'
     def copy_all
-      tables = ActiveRecord::Base.connection.tables
+      tables = ActiveRecord::Base.connection.tables.map(&:chop)
       regexps = options[:excludes].map{ |exclude| Regexp.new(exclude) }
       excludes = get_excludes(tables, regexps)
       @logger.info("exlude tables => #{excludes.join(',')}") unless excludes.empty?

--- a/lib/redshiftex/core.rb
+++ b/lib/redshiftex/core.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 require 'logger'
-require 'timeout'
+require 'timeout' unless defined?(Timeout)
 
 module Redshiftex
   class Core
@@ -11,7 +11,7 @@ module Redshiftex
     end
 
     def connection(path, environment)
-      @yaml = YAML.load(ERB.new(File.read(path)).result)    
+      @yaml = YAML.load(ERB.new(File.read(path)).result)
       @yaml = @yaml[environment] if environment
       @yaml
     end


### PR DESCRIPTION
Fix 2 problems.

- 1. When use bundler version 1.14.5 and above, cause error ```NameError: uninitialized constant Redshiftex::Core::TimeoutError```
    - see : https://github.com/bundler/bundler/issues/5582
- 2. When use command ```copy_all```, failed it. because all table names has dot at last.  add remove function.
    - e.g. table1. -> table1